### PR TITLE
Handling system tables errors

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -422,6 +422,10 @@ is_superuser(void)
 	return false;
 }
 
+ /*
+ * Check if the tables are System tables releated to pg_catalog or information_schema 
+ * throw a meaning full error to use VACUUM FULL for those tables.
+ */
 bool
 check_systemtables()
 {

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -614,6 +614,7 @@ is_requested_relation_exists(char *errbuf, size_t errsize){
 	int				num_relations;
 	SimpleStringListCell   *cell;
 
+	/*Handling system tables to return meaningful error message*/
 	if (check_systemtables()) {
 		if (errbuf)
 			snprintf(errbuf, errsize,"For System tables use VACUUM FULL.");

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -424,7 +424,6 @@ is_superuser(void)
 
 bool
 check_systemtables()
-
 {
 	PGresult	*query_result = NULL;
 	int	num;
@@ -454,11 +453,10 @@ check_systemtables()
 	{
 		if (PQntuples(query_result) >= 1)
 		{
+			CLEARPGRES(query_result); 
 			return true;
 		}
 	}
-
-	CLEARPGRES(query_result); 
 
 	return false;
 }
@@ -526,12 +524,6 @@ preliminary_checks(char *errbuf, size_t errsize){
 		if (errbuf)
 			snprintf(errbuf, errsize, "You must be a superuser to use %s",
 					 PROGRAM_NAME);
-		goto cleanup;
-	}
-
-	if (check_systemtables()) {
-		if (errbuf)
-			snprintf(errbuf, errsize, "For System Tables Use VACUUM FULL.");
 		goto cleanup;
 	}
 
@@ -621,6 +613,12 @@ is_requested_relation_exists(char *errbuf, size_t errsize){
 	StringInfoData	sql;
 	int				num_relations;
 	SimpleStringListCell   *cell;
+
+	if (check_systemtables()) {
+		if (errbuf)
+			snprintf(errbuf, errsize,"For System tables use VACUUM FULL.");
+		return false;
+	}
 
 	num_relations = simple_string_list_size(parent_table_list) +
 					simple_string_list_size(table_list);


### PR DESCRIPTION
Hey All,

Sorry for delay. there is a problem with my email. 

As mentioned I have reviewed the code and did some cleanup , added comments also.

As per suggestions on PR https://github.com/reorg/pg_repack/pull/327 I have looked in both `repack_one_table()` and `repack_table_indexes()` but the `ERROR:  relation pg_class does not exist `is coming from `is_requested_relation_exists()` before checking the function `check_systemtables()`.

So I have added `check_systemtables()` in `is_requested_relation_exists()` so that it will be clear for understanding and enhance in future.

Please let me know your thoughts. once this branch is merged I will create pull request to reorg/pg_repack.

Thanks.







